### PR TITLE
Feature additions and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -383,3 +383,4 @@ log_file.txt
 project.ioc
 mx.scratch
 *.tilen majerle
+*.exe

--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ Alternatively you may:
 
 1. Report a bug
 2. Ask for a feature request
+
+## Test
+
+To build the code and run basic tests on your host::
+
+        cd examples
+        make test

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -4,7 +4,8 @@
 TARGETS := \
 	example.exe \
 	example_stat.exe \
-	test.exe
+	test_code.exe \
+	test_time.exe
 
 .PHONY: all clean test
 all: $(TARGETS)
@@ -19,17 +20,21 @@ test: $(TARGETS)
 	done
 
 CFLAGS += -Wall \
-	  -DGPS_CFG_STATEMENT_PUBX=1 \
-	  -DGPS_CFG_STATEMENT_PUBX_TIME=1 \
 	  -DDEBUG=1 \
-	-I../gps_nmea_parser/src/include
+	-I../gps_nmea_parser/src/include \
+	-I./
 
 example.exe: example.c
 
 example_stat.exe: CFLAGS += -DGPS_CFG_STATUS=1
 example_stat.exe: example_stat.c
 
-test.exe: ../gps_nmea_parser/src/gps/gps.c test_code.c ../dev/VisualStudio/main.c
+test_code.exe: ../gps_nmea_parser/src/gps/gps.c test_code.c ../dev/VisualStudio/main.c
+
+test_time.exe: CFLAGS += \
+	  -DGPS_CFG_STATEMENT_PUBX=1 \
+	  -DGPS_CFG_STATEMENT_PUBX_TIME=1
+test_time.exe: ../gps_nmea_parser/src/gps/gps.c test_time.c ../dev/VisualStudio/main.c
 
 $(TARGETS) : ../gps_nmea_parser/src/gps/gps.c
 	$(CC) -o $@ $(CFLAGS) $^

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,27 @@
+# gps-nmea-parser examples and tests Makefile
+# (c) 2020 Sirio, Balmelli Analog & Digital
+
+TARGETS := example.exe test.exe
+
+.PHONY: all clean test
+all: $(TARGETS)
+
+clean:
+	@rm -fv $(TARGETS)
+
+test: $(TARGETS)
+	./example.exe
+	./test.exe
+
+
+CFLAGS += -Wall \
+	  -DGPS_CFG_STATEMENT_PUBX=1 \
+	  -DGPS_CFG_STATEMENT_PUBX_TIME=1 \
+	  -DDEBUG=1 \
+	-I../gps_nmea_parser/src/include
+
+test.exe: ../gps_nmea_parser/src/gps/gps.c test_code.c ../dev/VisualStudio/main.c
+	$(CC) -o $@ $(CFLAGS) $^
+
+%.exe : ../gps_nmea_parser/src/gps/gps.c %.c
+	$(CC) -o $@ $(CFLAGS) $^

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,10 @@
 # gps-nmea-parser examples and tests Makefile
 # (c) 2020 Sirio, Balmelli Analog & Digital
 
-TARGETS := example.exe test.exe
+TARGETS := \
+	example.exe \
+	example_stat.exe \
+	test.exe
 
 .PHONY: all clean test
 all: $(TARGETS)
@@ -10,9 +13,10 @@ clean:
 	@rm -fv $(TARGETS)
 
 test: $(TARGETS)
-	./example.exe
-	./test.exe
-
+	@for tgt in $(TARGETS); do \
+		echo "\n--- $$tgt ---"; \
+		./$$tgt; \
+	done
 
 CFLAGS += -Wall \
 	  -DGPS_CFG_STATEMENT_PUBX=1 \
@@ -20,8 +24,12 @@ CFLAGS += -Wall \
 	  -DDEBUG=1 \
 	-I../gps_nmea_parser/src/include
 
-test.exe: ../gps_nmea_parser/src/gps/gps.c test_code.c ../dev/VisualStudio/main.c
-	$(CC) -o $@ $(CFLAGS) $^
+example.exe: example.c
 
-%.exe : ../gps_nmea_parser/src/gps/gps.c %.c
+example_stat.exe: CFLAGS += -DGPS_CFG_STATUS=1
+example_stat.exe: example_stat.c
+
+test.exe: ../gps_nmea_parser/src/gps/gps.c test_code.c ../dev/VisualStudio/main.c
+
+$(TARGETS) : ../gps_nmea_parser/src/gps/gps.c
 	$(CC) -o $@ $(CFLAGS) $^

--- a/examples/example_stat.c
+++ b/examples/example_stat.c
@@ -1,10 +1,14 @@
 /**
- * This example uses direct processing function
- * to process dummy NMEA data from GPS receiver
+ * This example tests the callback functionality of gps_process()
+ * when the GPS_CFG_STATUS flag is set.
  */
 #include "gps/gps.h"
 #include <string.h>
 #include <stdio.h>
+
+#if ! GPS_CFG_STATUS
+#error "this test must be compiled with -DGPS_CFG_STATUS=1"
+#endif /* ! GPS_CFG_STATUS */
 
 /* GPS handle  */
 gps_t hgps;
@@ -29,19 +33,44 @@ gps_rx_data[] = ""
 "$GPRMC,183731,A,3907.482,N,12102.436,W,000.0,360.0,080301,015.5,E*67\r\n"
 "$GPRMB,A,,,,,,,,,,,,V*71\r\n";
 
+const gps_statement_t expected[] = {
+    STAT_RMC,
+    STAT_UNKNOWN,
+    STAT_GGA,
+    STAT_GSA,
+    STAT_GSV,
+    STAT_GSV,
+    STAT_UNKNOWN,
+    STAT_UNKNOWN,
+    STAT_UNKNOWN,
+    STAT_CHECKSUM_FAIL,
+    STAT_UNKNOWN,
+    STAT_UNKNOWN,
+    STAT_RMC,
+    STAT_UNKNOWN
+};
+
+static int err_cnt;
+
+void callback(gps_statement_t res) {
+    static int i;
+
+    if (res != expected[i]) {
+        printf("failed i %d, expected res %d but received %d\n",
+                i, expected[i], res);
+        err_cnt++;
+    }
+
+    i++;
+}
+
 int
 main() {
     /* Init GPS */
     gps_init(&hgps);
 
     /* Process all input data */
-    gps_process(&hgps, gps_rx_data, strlen(gps_rx_data));
+    gps_process(&hgps, gps_rx_data, strlen(gps_rx_data), callback);
 
-    /* Print messages */
-    printf("Valid status: %d\r\n", hgps.is_valid);
-    printf("Latitude: %f degrees\r\n", hgps.latitude);
-    printf("Longitude: %f degrees\r\n", hgps.longitude);
-    printf("Altitude: %f meters\r\n", hgps.altitude);
-
-    return 0;
+    return err_cnt;
 }

--- a/examples/example_stat.c
+++ b/examples/example_stat.c
@@ -58,10 +58,10 @@ void callback(gps_statement_t res) {
     if (res != expected[i]) {
         printf("failed i %d, expected res %d but received %d\n",
                 i, expected[i], res);
-        err_cnt++;
+        ++err_cnt;
     }
 
-    i++;
+    ++i;
 }
 
 int

--- a/examples/test_code.c
+++ b/examples/test_code.c
@@ -30,6 +30,10 @@ gps_rx_data[] = ""
 "$GPGSA,A,3,02,,,07,,09,24,26,,,,,1.6,1.6,1.0*3D\r\n"
 "$GPGSV,2,1,08,02,43,088,38,04,42,145,00,05,11,291,00,07,60,043,35*71\r\n"
 "$GPGSV,2,2,08,08,02,145,00,09,46,303,47,24,16,178,32,26,18,231,43*77\r\n"
+#if GPS_CFG_STATEMENT_PUBX_TIME
+"$PUBX,04*37\r\n"
+"$PUBX,04,073731.00,091202,113851.00,1196,15D,1930035,-2660.664,43*71\r\n"
+#endif /* GPS_CFG_STATEMENT_PUBX_TIME */
 "";
 
 /**
@@ -72,10 +76,25 @@ run_tests() {
     RUN_TEST(INT_IS_EQUAL(hgps.satellites_ids[10], 0));
     RUN_TEST(INT_IS_EQUAL(hgps.satellites_ids[11], 0));
 
+#if GPS_CFG_STATEMENT_PUBX_TIME
+    RUN_TEST(INT_IS_EQUAL(hgps.hours, 7));
+    RUN_TEST(INT_IS_EQUAL(hgps.minutes, 37));
+    RUN_TEST(INT_IS_EQUAL(hgps.seconds, 31));
+    RUN_TEST(INT_IS_EQUAL(hgps.date, 9));
+    RUN_TEST(INT_IS_EQUAL(hgps.month, 12));
+    RUN_TEST(INT_IS_EQUAL(hgps.year, 2));
+    RUN_TEST(FLT_IS_EQUAL(hgps.utc_tow, 113851.00));
+    RUN_TEST(INT_IS_EQUAL(hgps.utc_wk, 1196));
+    RUN_TEST(INT_IS_EQUAL(hgps.leap_sec, 15));
+    RUN_TEST(INT_IS_EQUAL(hgps.clk_bias, 1930035));
+    RUN_TEST(FLT_IS_EQUAL(hgps.clk_drift, -2660.664));
+    RUN_TEST(INT_IS_EQUAL(hgps.tp_gran, 43));
+#else
     RUN_TEST(INT_IS_EQUAL(hgps.date, 8));
     RUN_TEST(INT_IS_EQUAL(hgps.month, 3));
     RUN_TEST(INT_IS_EQUAL(hgps.year, 1));
     RUN_TEST(INT_IS_EQUAL(hgps.hours, 18));
     RUN_TEST(INT_IS_EQUAL(hgps.minutes, 37));
     RUN_TEST(INT_IS_EQUAL(hgps.seconds, 30));
+#endif /* GPS_CFG_STATEMENT_PUBX_TIME */
 }

--- a/examples/test_code.c
+++ b/examples/test_code.c
@@ -5,7 +5,7 @@
 #include "gps/gps.h"
 #include <string.h>
 #include <stdio.h>
-#include <test_common.h>
+#include "test_common.h"
 
 /* GPS handle  */
 gps_t hgps;

--- a/examples/test_code.c
+++ b/examples/test_code.c
@@ -5,17 +5,7 @@
 #include "gps/gps.h"
 #include <string.h>
 #include <stdio.h>
-#include <math.h>
-
-#define RUN_TEST(x)         do {                \
-    if ((x)) {                                  \
-        printf("Test passed on line %u with condition " # x "\r\n", (unsigned)__LINE__);\
-    } else {                                    \
-        printf("Test FAILED on line %u with condition " # x "\r\n", (unsigned)__LINE__ );   \
-    }                                           \
-} while (0)
-#define FLT_IS_EQUAL(x, y)      (fabs((double)(x) - (double)(y)) < 0.00001)
-#define INT_IS_EQUAL(x, y)      ((int)((x) == (y)))
+#include <test_common.h>
 
 /* GPS handle  */
 gps_t hgps;
@@ -30,10 +20,6 @@ gps_rx_data[] = ""
 "$GPGSA,A,3,02,,,07,,09,24,26,,,,,1.6,1.6,1.0*3D\r\n"
 "$GPGSV,2,1,08,02,43,088,38,04,42,145,00,05,11,291,00,07,60,043,35*71\r\n"
 "$GPGSV,2,2,08,08,02,145,00,09,46,303,47,24,16,178,32,26,18,231,43*77\r\n"
-#if GPS_CFG_STATEMENT_PUBX_TIME
-"$PUBX,04*37\r\n"
-"$PUBX,04,073731.00,091202,113851.00,1196,15D,1930035,-2660.664,43*71\r\n"
-#endif /* GPS_CFG_STATEMENT_PUBX_TIME */
 "";
 
 /**
@@ -76,25 +62,10 @@ run_tests() {
     RUN_TEST(INT_IS_EQUAL(hgps.satellites_ids[10], 0));
     RUN_TEST(INT_IS_EQUAL(hgps.satellites_ids[11], 0));
 
-#if GPS_CFG_STATEMENT_PUBX_TIME
-    RUN_TEST(INT_IS_EQUAL(hgps.hours, 7));
-    RUN_TEST(INT_IS_EQUAL(hgps.minutes, 37));
-    RUN_TEST(INT_IS_EQUAL(hgps.seconds, 31));
-    RUN_TEST(INT_IS_EQUAL(hgps.date, 9));
-    RUN_TEST(INT_IS_EQUAL(hgps.month, 12));
-    RUN_TEST(INT_IS_EQUAL(hgps.year, 2));
-    RUN_TEST(FLT_IS_EQUAL(hgps.utc_tow, 113851.00));
-    RUN_TEST(INT_IS_EQUAL(hgps.utc_wk, 1196));
-    RUN_TEST(INT_IS_EQUAL(hgps.leap_sec, 15));
-    RUN_TEST(INT_IS_EQUAL(hgps.clk_bias, 1930035));
-    RUN_TEST(FLT_IS_EQUAL(hgps.clk_drift, -2660.664));
-    RUN_TEST(INT_IS_EQUAL(hgps.tp_gran, 43));
-#else
     RUN_TEST(INT_IS_EQUAL(hgps.date, 8));
     RUN_TEST(INT_IS_EQUAL(hgps.month, 3));
     RUN_TEST(INT_IS_EQUAL(hgps.year, 1));
     RUN_TEST(INT_IS_EQUAL(hgps.hours, 18));
     RUN_TEST(INT_IS_EQUAL(hgps.minutes, 37));
     RUN_TEST(INT_IS_EQUAL(hgps.seconds, 30));
-#endif /* GPS_CFG_STATEMENT_PUBX_TIME */
 }

--- a/examples/test_common.h
+++ b/examples/test_common.h
@@ -1,0 +1,18 @@
+#ifndef test_common_h_
+#define test_common_h_
+
+#include <math.h>
+#include <stdlib.h>
+
+#define RUN_TEST(x)         do {                \
+    if ((x)) {                                  \
+        printf("Test passed on line %u with condition " # x "\r\n", (unsigned)__LINE__); \
+    } else {                                    \
+        printf("Test FAILED on line %u with condition " # x "\r\n", (unsigned)__LINE__ ); \
+        exit(1);                                \
+    }                                           \
+} while (0)
+#define FLT_IS_EQUAL(x, y)      (fabs((double)(x) - (double)(y)) < 0.00001)
+#define INT_IS_EQUAL(x, y)      ((int)((x) == (y)))
+
+#endif /* test_common_h_ */

--- a/examples/test_common.h
+++ b/examples/test_common.h
@@ -1,5 +1,5 @@
-#ifndef test_common_h_
-#define test_common_h_
+#ifndef TEST_COMMON_HDR_H
+#define TEST_COMMON_HDR_H
 
 #include <math.h>
 #include <stdlib.h>
@@ -15,4 +15,4 @@
 #define FLT_IS_EQUAL(x, y)      (fabs((double)(x) - (double)(y)) < 0.00001)
 #define INT_IS_EQUAL(x, y)      ((int)((x) == (y)))
 
-#endif /* test_common_h_ */
+#endif /* TEST_COMMON_HDR_H */

--- a/examples/test_time.c
+++ b/examples/test_time.c
@@ -62,7 +62,6 @@ run_tests() {
     RUN_TEST(INT_IS_EQUAL(hgps.year, 20));
     RUN_TEST(FLT_IS_EQUAL(hgps.utc_tow, 158834.00));
     RUN_TEST(INT_IS_EQUAL(hgps.utc_wk, 2098));
-    printf("leap_sec %d\n", hgps.leap_sec);
     RUN_TEST(INT_IS_EQUAL(hgps.leap_sec, 18));
     RUN_TEST(INT_IS_EQUAL(hgps.clk_bias, 536057));
     RUN_TEST(FLT_IS_EQUAL(hgps.clk_drift, 257.043));

--- a/examples/test_time.c
+++ b/examples/test_time.c
@@ -1,0 +1,70 @@
+/*
+ * This example uses direct processing function,
+ * to process dummy PUBX TIME packets from GPS receiver
+ */
+#include "gps/gps.h"
+#include <string.h>
+#include <stdio.h>
+#include <test_common.h>
+
+#if ! GPS_CFG_STATEMENT_PUBX_TIME
+#error "this test must be compiled with -DGPS_CFG_STATEMENT_PUBX_TIME=1"
+#endif /* ! GPS_CFG_STATEMENT_PUBX_TIME */
+
+/* GPS handle  */
+gps_t hgps;
+
+/**
+ * \brief           Dummy data from GPS receiver
+ */
+const char
+gps_rx_data_A[] = ""
+"$PUBX,04*37\r\n"
+"$PUBX,04,073731.00,091202,113851.00,1196,15D,1930035,-2660.664,43*71\r\n"
+"";
+const char
+gps_rx_data_B[] = ""
+"$PUBX,04,200714.00,230320,158834.00,2098,18,536057,257.043,16*12\r\b"
+"";
+
+
+/**
+ * \brief           Run the test of raw input data
+ */
+void
+run_tests() {
+    gps_init(&hgps);                            /* Init GPS */
+
+    /* Process and test block A */
+    gps_process(&hgps, gps_rx_data_A, strlen(gps_rx_data_A));
+
+    RUN_TEST(INT_IS_EQUAL(hgps.hours, 7));
+    RUN_TEST(INT_IS_EQUAL(hgps.minutes, 37));
+    RUN_TEST(INT_IS_EQUAL(hgps.seconds, 31));
+    RUN_TEST(INT_IS_EQUAL(hgps.date, 9));
+    RUN_TEST(INT_IS_EQUAL(hgps.month, 12));
+    RUN_TEST(INT_IS_EQUAL(hgps.year, 2));
+    RUN_TEST(FLT_IS_EQUAL(hgps.utc_tow, 113851.00));
+    RUN_TEST(INT_IS_EQUAL(hgps.utc_wk, 1196));
+    RUN_TEST(INT_IS_EQUAL(hgps.leap_sec, 15));
+    RUN_TEST(INT_IS_EQUAL(hgps.clk_bias, 1930035));
+    RUN_TEST(FLT_IS_EQUAL(hgps.clk_drift, -2660.664));
+    RUN_TEST(INT_IS_EQUAL(hgps.tp_gran, 43));
+
+    /* Process and test block B */
+    gps_process(&hgps, gps_rx_data_B, strlen(gps_rx_data_B));
+
+    RUN_TEST(INT_IS_EQUAL(hgps.hours, 20));
+    RUN_TEST(INT_IS_EQUAL(hgps.minutes, 7));
+    RUN_TEST(INT_IS_EQUAL(hgps.seconds, 14));
+    RUN_TEST(INT_IS_EQUAL(hgps.date, 23));
+    RUN_TEST(INT_IS_EQUAL(hgps.month, 3));
+    RUN_TEST(INT_IS_EQUAL(hgps.year, 20));
+    RUN_TEST(FLT_IS_EQUAL(hgps.utc_tow, 158834.00));
+    RUN_TEST(INT_IS_EQUAL(hgps.utc_wk, 2098));
+    printf("leap_sec %d\n", hgps.leap_sec);
+    RUN_TEST(INT_IS_EQUAL(hgps.leap_sec, 18));
+    RUN_TEST(INT_IS_EQUAL(hgps.clk_bias, 536057));
+    RUN_TEST(FLT_IS_EQUAL(hgps.clk_drift, 257.043));
+    RUN_TEST(INT_IS_EQUAL(hgps.tp_gran, 16));
+}

--- a/examples/test_time.c
+++ b/examples/test_time.c
@@ -2,9 +2,9 @@
  * This example uses direct processing function,
  * to process dummy PUBX TIME packets from GPS receiver
  */
-#include "gps/gps.h"
 #include <string.h>
 #include <stdio.h>
+#include "gps/gps.h"
 #include "test_common.h"
 
 #if ! GPS_CFG_STATEMENT_PUBX_TIME

--- a/examples/test_time.c
+++ b/examples/test_time.c
@@ -5,7 +5,7 @@
 #include "gps/gps.h"
 #include <string.h>
 #include <stdio.h>
-#include <test_common.h>
+#include "test_common.h"
 
 #if ! GPS_CFG_STATEMENT_PUBX_TIME
 #error "this test must be compiled with -DGPS_CFG_STATEMENT_PUBX_TIME=1"

--- a/gps_nmea_parser/src/gps/gps.c
+++ b/gps_nmea_parser/src/gps/gps.c
@@ -50,14 +50,6 @@
 #define R2D(x)              FLT(FLT(x) * FLT(57.29577951308232))/*!< Radians to degrees */
 #define EARTH_RADIUS        FLT(6371.0) /*!< Earth radius in units of kilometers */
 
-#define STAT_UNKNOWN        0
-#define STAT_GGA            1
-#define STAT_GSA            2
-#define STAT_GSV            3
-#define STAT_RMC            4
-#define STAT_UBX            5
-#define STAT_UBX_TIME       6
-
 #define CRC_ADD(_gh, ch)    (_gh)->p.crc_calc ^= (uint8_t)(ch)
 #define TERM_ADD(_gh, ch)   do {    \
     if ((_gh)->p.term_pos < (sizeof((_gh)->p.term_str) - 1)) {  \

--- a/gps_nmea_parser/src/gps/gps.c
+++ b/gps_nmea_parser/src/gps/gps.c
@@ -36,14 +36,6 @@
 #include <stdlib.h>
 #include "gps/gps.h"
 
-#if DEBUG
-#ifndef DEBUG_PRINTF
-#include <stdio.h>
-#define DEBUG_PRINTF(MESSAGE, ...) \
-    printf(MESSAGE, ##__VA_ARGS__)
-#endif
-#endif /* DEBUG */
-
 #define FLT(x)              ((gps_float_t)(x))
 #define D2R(x)              FLT(FLT(x) * FLT(0.01745329251994)) /*!< Degrees to radians */
 #define R2D(x)              FLT(FLT(x) * FLT(57.29577951308232))/*!< Radians to degrees */
@@ -350,10 +342,6 @@ static uint8_t
 check_crc(gps_t* gh) {
     uint8_t crc;
     crc = (uint8_t)((CHTN(gh->p.term_str[0]) & 0x0F) << 0x04) | (CHTN(gh->p.term_str[1]) & 0x0F);   /* Convert received CRC from string (hex) to number */
-#if DEBUG
-    if (gh->p.crc_calc != crc)
-        DEBUG_PRINTF("computed CRC 0x%02x != expected CRC 0x%02x\n", gh->p.crc_calc, crc);
-#endif /* DEBUG */
     return gh->p.crc_calc == crc;               /* They must match! */
 }
 

--- a/gps_nmea_parser/src/gps/gps.c
+++ b/gps_nmea_parser/src/gps/gps.c
@@ -37,6 +37,14 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if DEBUG
+#ifndef DEBUG_PRINTF
+#include <stdio.h>
+#define DEBUG_PRINTF(MESSAGE, ...) \
+    printf(MESSAGE, ##__VA_ARGS__)
+#endif
+#endif /* DEBUG */
+
 #define FLT(x)              ((gps_float_t)(x))
 #define D2R(x)              FLT(FLT(x) * FLT(0.01745329251994)) /*!< Degrees to radians */
 #define R2D(x)              FLT(FLT(x) * FLT(57.29577951308232))/*!< Radians to degrees */
@@ -295,6 +303,10 @@ static uint8_t
 check_crc(gps_t* gh) {
     uint8_t crc;
     crc = (uint8_t)((CHTN(gh->p.term_str[0]) & 0x0F) << 0x04) | (CHTN(gh->p.term_str[1]) & 0x0F);   /* Convert received CRC from string (hex) to number */
+#if DEBUG
+    if (gh->p.crc_calc != crc)
+        DEBUG_PRINTF("computed CRC 0x%02x != expected CRC 0x%02x\n", gh->p.crc_calc, crc);
+#endif /* DEBUG */
     return gh->p.crc_calc == crc;               /* They must match! */
 }
 

--- a/gps_nmea_parser/src/gps/gps.c
+++ b/gps_nmea_parser/src/gps/gps.c
@@ -426,7 +426,7 @@ gps_init(gps_t* gh) {
  */
 uint8_t
 #if GPS_CFG_STATUS
-gps_process(gps_t* gh, const void* data, size_t len, gps_process_cb_t callback) {
+gps_process(gps_t* gh, const void* data, size_t len, gps_process_cb_t evt_fn) {
 #else
 gps_process(gps_t* gh, const void* data, size_t len) {
 #endif /* GPS_CFG_STATUS */
@@ -449,11 +449,11 @@ gps_process(gps_t* gh, const void* data, size_t len) {
                 /* CRC is OK, in theory we can copy data from statements to user data */
                 copy_from_tmp_memory(gh);       /* Copy memory from temporary to user memory */
 #if GPS_CFG_STATUS
-                if (callback) {
-                    callback(gh->p.stat);
+                if (evt_fn != NULL) {
+                    evt_fn(gh->p.stat);
                 }
-            } else if (callback) {
-                callback(STAT_CHECKSUM_FAIL);
+            } else if (evt_fn != NULL) {
+                evt_fn(STAT_CHECKSUM_FAIL);
 #endif /* GPS_CFG_STATUS */
             }
         } else {

--- a/gps_nmea_parser/src/gps/gps.c
+++ b/gps_nmea_parser/src/gps/gps.c
@@ -438,7 +438,11 @@ gps_init(gps_t* gh) {
  * \return          `1` on success, `0` otherwise
  */
 uint8_t
+#if GPS_CFG_STATUS
+gps_process(gps_t* gh, const void* data, size_t len, gps_process_cb_t callback) {
+#else
 gps_process(gps_t* gh, const void* data, size_t len) {
+#endif /* GPS_CFG_STATUS */
     const uint8_t* d = data;
 
     while (len--) {                             /* Process all bytes */
@@ -457,6 +461,13 @@ gps_process(gps_t* gh, const void* data, size_t len) {
             if (check_crc(gh)) {                /* Check for CRC result */
                 /* CRC is OK, in theory we can copy data from statements to user data */
                 copy_from_tmp_memory(gh);       /* Copy memory from temporary to user memory */
+#if GPS_CFG_STATUS
+                if (callback) {
+                    callback(gh->p.stat);
+                }
+            } else if (callback) {
+                callback(STAT_CHECKSUM_FAIL);
+#endif /* GPS_CFG_STATUS */
             }
         } else {
             if (!gh->p.star) {                  /* Add to CRC only if star not yet detected */

--- a/gps_nmea_parser/src/gps/gps.c
+++ b/gps_nmea_parser/src/gps/gps.c
@@ -316,7 +316,7 @@ parse_term(gps_t* gh) {
                 /* Accomodate a 2- or 3-digit leap second count;
                  * a trailing 'D' means this is the firmware's default value.
                  */
-                if (gh->p.term_str[2] == 'D' || gh->p.term_str[2] == ',') {
+                if (gh->p.term_str[2] == 'D' || gh->p.term_str[2] == '\0') {
                     gh->p.data.time.leap_sec = 10 * CTN(gh->p.term_str[0])
                                                 + CTN(gh->p.term_str[1]);
                 } else {

--- a/gps_nmea_parser/src/gps/gps.c
+++ b/gps_nmea_parser/src/gps/gps.c
@@ -426,7 +426,7 @@ gps_init(gps_t* gh) {
  */
 uint8_t
 #if GPS_CFG_STATUS
-gps_process(gps_t* gh, const void* data, size_t len, gps_process_cb_t evt_fn) {
+gps_process(gps_t* gh, const void* data, size_t len, gps_process_fn evt_fn) {
 #else
 gps_process(gps_t* gh, const void* data, size_t len) {
 #endif /* GPS_CFG_STATUS */

--- a/gps_nmea_parser/src/include/gps/gps.h
+++ b/gps_nmea_parser/src/include/gps/gps.h
@@ -59,6 +59,16 @@ extern "C" {
 #endif
 
 /**
+ * \brief           Enables `1` or disables `0` status reporting callback
+ *                  by gps_process()
+ *
+ * \note            This is an extension, so not enabled by default.
+ */
+#ifndef GPS_CFG_STATUS
+#define GPS_CFG_STATUS                      0
+#endif
+
+/**
  * \brief           Enables `1` or disables `0` `GGA` statement parsing.
  *
  * \note            This statement must be enabled to parse:
@@ -186,7 +196,8 @@ typedef enum {
     STAT_GSV        = 3,
     STAT_RMC        = 4,
     STAT_UBX        = 5,
-    STAT_UBX_TIME   = 6
+    STAT_UBX_TIME   = 6,
+    STAT_CHECKSUM_FAIL = UINT8_MAX
 }__attribute__((packed)) gps_statement_t;
 /**
  * \brief           GPS main structure
@@ -369,7 +380,13 @@ typedef enum {
 } gps_speed_t;
 
 uint8_t     gps_init(gps_t* gh);
+
+#if GPS_CFG_STATUS
+typedef void (*gps_process_cb_t)(gps_statement_t res);
+uint8_t     gps_process(gps_t* gh, const void* data, size_t len, gps_process_cb_t callback);
+#else
 uint8_t     gps_process(gps_t* gh, const void* data, size_t len);
+#endif /* GPS_CFG_STATUS */
 
 uint8_t     gps_distance_bearing(gps_float_t las, gps_float_t los, gps_float_t lae, gps_float_t loe, gps_float_t* d, gps_float_t* b);
 gps_float_t gps_to_speed(gps_float_t sik, gps_speed_t ts);

--- a/gps_nmea_parser/src/include/gps/gps.h
+++ b/gps_nmea_parser/src/include/gps/gps.h
@@ -383,7 +383,7 @@ uint8_t     gps_init(gps_t* gh);
 
 #if GPS_CFG_STATUS
 typedef void (*gps_process_cb_t)(gps_statement_t res);
-uint8_t     gps_process(gps_t* gh, const void* data, size_t len, gps_process_cb_t callback);
+uint8_t     gps_process(gps_t* gh, const void* data, size_t len, gps_process_cb_t evt_fn);
 #else
 uint8_t     gps_process(gps_t* gh, const void* data, size_t len);
 #endif /* GPS_CFG_STATUS */

--- a/gps_nmea_parser/src/include/gps/gps.h
+++ b/gps_nmea_parser/src/include/gps/gps.h
@@ -116,6 +116,37 @@ extern "C" {
 #endif
 
 /**
+ * \brief           Enables `1` or disables `0` parsing and generation
+ *                  of PUBX (uBlox) messages
+ *
+ *                  PUBX are a nonstandard ublox-specific extensions,
+ *                  so disabled by default.
+ */
+#ifndef GPS_CFG_STATEMENT_PUBX
+#define GPS_CFG_STATEMENT_PUBX     0
+#endif
+
+#if GPS_CFG_STATEMENT_PUBX
+
+/**
+ * \brief           Enables `1` or disables `0` parsing and generation
+ *                  of PUBX (uBlox) TIME messages.
+ *
+ * \note            TIME messages can be used to obtain:
+ *                      - UTC time of week
+ *                      - UTC week number
+ *                      - Leap seconds (allows conversion to eg. TAI)
+ *
+ *                  This is a nonstandard ublox-specific extension,
+ *                  so disabled by default.
+ */
+#ifndef GPS_CFG_STATEMENT_PUBX_TIME
+#define GPS_CFG_STATEMENT_PUBX_TIME     0
+#endif
+
+#endif /* GPS_CFG_STATEMENT_PUBX */
+
+/**
  * \}
  */
 
@@ -190,6 +221,28 @@ typedef struct {
     uint8_t year;                               /*!< Fix year */
 #endif /* GPS_CFG_STATEMENT_GPRMC || __DOXYGEN__ */
 
+#if GPS_CFG_STATEMENT_PUBX_TIME || __DOXYGEN__
+#if ! GPS_CFG_STATEMENT_GPGGA && ! __DOXYGEN__
+    /* rely on time fields from GPGGA if possible */
+    uint8_t hours;
+    uint8_t minutes;
+    uint8_t seconds;
+#endif /* ! GPS_CFG_STATEMENT_GPGGA && ! __DOXYGEN__ */
+#if ! GPS_CFG_STATEMENT_GPRMC && ! __DOXYGEN__
+    /* rely on date fields from GPRMC if possible */
+    uint8_t date;
+    uint8_t month;
+    uint8_t year;
+#endif /* ! GPS_CFG_STATEMENT_GPRMC && ! __DOXYGEN__ */
+    /* fields only available in PUBX_TIME */
+    gps_float_t utc_tow;                        /*!< UTC TimeOfWeek, eg 113851.00 */
+    uint16_t utc_wk;                            /*!< UTC week number, continues beyond 1023 */
+    uint8_t leap_sec;                           /*!< UTC leap seconds; UTC + leap_sec = TAI */
+    uint32_t clk_bias;                          /*!< Receiver clock bias, eg 1930035 */
+    gps_float_t clk_drift;                      /*!< Receiver clock drift, eg -2660.664 */
+    uint32_t tp_gran;                           /*!< Time pulse granularity, eg 43 */
+#endif /* GPS_CFG_STATEMENT_PUBX_TIME || __DOXYGEN__ */
+
 #if !__DOXYGEN__
     struct {
         uint8_t stat;                           /*!< Statement index */
@@ -242,6 +295,22 @@ typedef struct {
                 gps_float_t variation;          /*!< Current magnetic variation in degrees */
             } rmc;                              /*!< GPRMC message */
 #endif /* GPS_CFG_STATEMENT_GPRMC */
+#if GPS_CFG_STATEMENT_PUBX_TIME
+            struct {
+                uint8_t hours;                  /*!< Current UTC hours */
+                uint8_t minutes;                /*!< Current UTC minutes */
+                uint8_t seconds;                /*!< Current UTC seconds */
+                uint8_t date;                   /*!< Current UTC date */
+                uint8_t month;                  /*!< Current UTC month */
+                uint8_t year;                   /*!< Current UTC year */
+                gps_float_t utc_tow;            /*!< UTC TimeOfWeek, eg 113851.00 */
+                uint16_t utc_wk;                /*!< UTC week number, continues beyond 1023 */
+                uint8_t leap_sec;               /*!< UTC leap seconds; UTC + leap_sec = TAI */
+                uint32_t clk_bias;              /*!< Receiver clock bias, eg 1930035 */
+                gps_float_t clk_drift;          /*!< Receiver clock drift, eg -2660.664 */
+                uint32_t tp_gran;               /*!< Time pulse granularity, eg 43 */
+            } time;                             /*!< PUBX TIME message */
+#endif /* GPS_CFG_STATEMENT_PUBX_TIME */
         } data;                                 /*!< Union with data for each information */
     } p;                                        /*!< Structure with private data */
 #endif /* !__DOXYGEN__ */

--- a/gps_nmea_parser/src/include/gps/gps.h
+++ b/gps_nmea_parser/src/include/gps/gps.h
@@ -177,6 +177,18 @@ typedef struct {
 } gps_sat_t;
 
 /**
+ * \brief           ENUM of possible GPS statements parsed
+ */
+typedef enum {
+    STAT_UNKNOWN    = 0,
+    STAT_GGA        = 1,
+    STAT_GSA        = 2,
+    STAT_GSV        = 3,
+    STAT_RMC        = 4,
+    STAT_UBX        = 5,
+    STAT_UBX_TIME   = 6
+}__attribute__((packed)) gps_statement_t;
+/**
  * \brief           GPS main structure
  */
 typedef struct {
@@ -245,7 +257,7 @@ typedef struct {
 
 #if !__DOXYGEN__
     struct {
-        uint8_t stat;                           /*!< Statement index */
+        gps_statement_t stat;                   /*!< Statement index */
         char term_str[13];                      /*!< Current term in string format */
         uint8_t term_pos;                       /*!< Current index position in term */
         uint8_t term_num;                       /*!< Current term number */

--- a/gps_nmea_parser/src/include/gps/gps.h
+++ b/gps_nmea_parser/src/include/gps/gps.h
@@ -198,7 +198,7 @@ typedef enum {
     STAT_UBX        = 5,
     STAT_UBX_TIME   = 6,
     STAT_CHECKSUM_FAIL = UINT8_MAX
-}__attribute__((packed)) gps_statement_t;
+} gps_statement_t;
 /**
  * \brief           GPS main structure
  */

--- a/gps_nmea_parser/src/include/gps/gps.h
+++ b/gps_nmea_parser/src/include/gps/gps.h
@@ -381,9 +381,14 @@ typedef enum {
 
 uint8_t     gps_init(gps_t* gh);
 
+/**
+ * \brief           Signature for caller-suplied callback function from gps_process
+ * \param[in]       res: statement type of recently parsed statement
+ */
+typedef void (*gps_process_fn)(gps_statement_t res);
+
 #if GPS_CFG_STATUS
-typedef void (*gps_process_cb_t)(gps_statement_t res);
-uint8_t     gps_process(gps_t* gh, const void* data, size_t len, gps_process_cb_t evt_fn);
+uint8_t     gps_process(gps_t* gh, const void* data, size_t len, gps_process_fn evt_fn);
 #else
 uint8_t     gps_process(gps_t* gh, const void* data, size_t len);
 #endif /* GPS_CFG_STATUS */

--- a/gps_nmea_parser/src/include/gps/gps.h
+++ b/gps_nmea_parser/src/include/gps/gps.h
@@ -136,8 +136,6 @@ extern "C" {
 #define GPS_CFG_STATEMENT_PUBX     0
 #endif
 
-#if GPS_CFG_STATEMENT_PUBX
-
 /**
  * \brief           Enables `1` or disables `0` parsing and generation
  *                  of PUBX (uBlox) TIME messages.
@@ -149,12 +147,16 @@ extern "C" {
  *
  *                  This is a nonstandard ublox-specific extension,
  *                  so disabled by default.
+ *
+ *                  This configure option requires GPS_CFG_STATEMENT_PUBX
  */
 #ifndef GPS_CFG_STATEMENT_PUBX_TIME
 #define GPS_CFG_STATEMENT_PUBX_TIME     0
 #endif
-
-#endif /* GPS_CFG_STATEMENT_PUBX */
+/* Guard against accidental parser breakage */
+#if GPS_CFG_STATEMENT_PUBX_TIME && !GPS_CFG_STATEMENT_PUBX
+#error GPS_CFG_STATEMENT_PUBX must be enabled when enabling GPS_CFG_STATEMENT_PUBX_TIME
+#endif /* GPS_CFG_STATEMENT_PUBX_TIME && !GPS_CFG_STATEMENT_PUBX */
 
 /**
  * \}

--- a/gps_nmea_parser/src/include/gps/gps.h
+++ b/gps_nmea_parser/src/include/gps/gps.h
@@ -245,18 +245,18 @@ typedef struct {
 #endif /* GPS_CFG_STATEMENT_GPRMC || __DOXYGEN__ */
 
 #if GPS_CFG_STATEMENT_PUBX_TIME || __DOXYGEN__
-#if ! GPS_CFG_STATEMENT_GPGGA && ! __DOXYGEN__
+#if !GPS_CFG_STATEMENT_GPGGA && !__DOXYGEN__
     /* rely on time fields from GPGGA if possible */
     uint8_t hours;
     uint8_t minutes;
     uint8_t seconds;
-#endif /* ! GPS_CFG_STATEMENT_GPGGA && ! __DOXYGEN__ */
-#if ! GPS_CFG_STATEMENT_GPRMC && ! __DOXYGEN__
+#endif /* !GPS_CFG_STATEMENT_GPGGA && !__DOXYGEN__ */
+#if !GPS_CFG_STATEMENT_GPRMC && !__DOXYGEN__
     /* rely on date fields from GPRMC if possible */
     uint8_t date;
     uint8_t month;
     uint8_t year;
-#endif /* ! GPS_CFG_STATEMENT_GPRMC && ! __DOXYGEN__ */
+#endif /* !GPS_CFG_STATEMENT_GPRMC && !__DOXYGEN__ */
     /* fields only available in PUBX_TIME */
     gps_float_t utc_tow;                        /*!< UTC TimeOfWeek, eg 113851.00 */
     uint16_t utc_wk;                            /*!< UTC week number, continues beyond 1023 */


### PR DESCRIPTION
This commit series:

1. Adds optional parsing for `PUBX TIME` messages (disabled by default).

    - This is pretty straightforward, just adding `#if` blocks, optional data fields in `gps_t` and Doxygen documentation on the option.

1. Adds optional status callback to `gps_process()` so callers can track messages received and/or have a vision into what the GPS is sending (disabled by default).

    - This required encoding GPS statement types as an enum `gps_statement_t`; care was taken that the compiler would pack this down to 8 bits.
    - The call signature for `gps_process()` was optionally changed to invoke a user-supplied callback on request.

1. Extends the existing test code, adds a Makefile and some documentation instructions on running tests.

    - Common test defines moved into `test_common.h`

These changes have been being used in downstream firmware for several weeks successfully and are mature enough to merge.